### PR TITLE
Rest member get

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can provide the access token in the client options as `accessToken` or throu
 ### Initialize the client object
 
 ```javascript
+const { GRClient } = require('global-registry-nodejs-client')
 const options = {baseUrl: ' ... ', accessToken: ' ... '}
 const client = new GRClient(options)
 ```
@@ -40,7 +41,10 @@ For example, to access EntityType resources:
  
 ```javascript
 // GET records
-client.EntityType.get( {filters: {name: 'person'}} ).then( result => ... )
+client.EntityType.get( {filters: {name: 'person'}} ).then( result => result.entities.map(e => e.entity_type) )
+
+// GET one record, by ID
+client.EntityType.getOne('1200beca-169c-4443-85b3-80611f5c25a5').then( result => result.entity.entity_type )
 
 // POST:
 client.EntityType.post({name: '', parent_id: ''}).then()

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,10 @@
 
 const { Configurator } = require('./config')
 const { HttpClient } = require('./http-client')
-const { GlobalRegistryObject } = require('./global-registry-object')
+const {
+  GlobalRegistryObject,
+  GlobalRegistrySubscriptionObject,
+  GlobalRegistryReadOnlyObject } = require('./global-registry-object')
 
 const grTypes = [
   {
@@ -25,14 +28,16 @@ const grTypes = [
     path: '/measurements/',
     name: 'measurement' },
   {
-    type: 'MeasurementType',
-    path: '/measurement_types/',
-    name: 'measurement_type' },
-  {
     type: 'System',
     path: '/systems/',
     name: 'system' }
+]
 
+const grReadOnlyTypes = [
+  {
+    type: 'MeasurementType',
+    path: '/measurement_types/',
+    name: 'measurement_type' }
 ]
 
 /**
@@ -61,6 +66,11 @@ class GRClient {
     grTypes.map(typeDef => {
       this[typeDef.type] = new GlobalRegistryObject(this.rawHttpClient, typeDef)
     })
+    grReadOnlyTypes.map(typeDef => {
+      this[typeDef.type] = new GlobalRegistryReadOnlyObject(this.rawHttpClient, typeDef)
+    })
+
+    this.Subscription = new GlobalRegistrySubscriptionObject(this.rawHttpClient)
   }
 }
 

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -37,6 +37,32 @@ describe('GRClient', () => {
       })
   })
 
+  test('Entity - GET one', () => {
+    const token = uuid.v4()
+    const options = { baseUrl: BASE_URL, accessToken: token }
+
+    const id = uuid.v4()
+
+    const expectedResult = {
+      entity: {
+        person: {
+          name: uuid.v4()
+        }
+      }
+    }
+
+    nock(BASE_URL, { reqheaders: headers(token) })
+      .get(`/entities/${id}`)
+      .reply(200, expectedResult)
+
+    const grClient = new GRClient(options)
+
+    return grClient.Entity.getOne(id)
+      .then(result => {
+        expect(result).toEqual(expectedResult)
+      })
+  })
+
   test('Entity - POST', () => {
     const token = uuid.v4()
     const options = { baseUrl: BASE_URL, accessToken: token }

--- a/lib/global-registry-object.js
+++ b/lib/global-registry-object.js
@@ -24,6 +24,10 @@ class GlobalRegistryObject {
     return this.httpClient.get(this.path, translateNestedParameters(params))
   }
 
+  getOne (id) {
+    return this.httpClient.get(this._pathWithId(id))
+  }
+
   _pathWithId (id) {
     return `${this.path}${id}`
   }

--- a/lib/global-registry-object.js
+++ b/lib/global-registry-object.js
@@ -1,35 +1,39 @@
 
 const { translateNestedParameters } = require('./http-client')
 
-class GlobalRegistryObject {
+class GlobalRegistryReadOnlyObject {
   constructor (httpClient, options) {
     this.httpClient = httpClient
     this.path = `/${options.path}/`.replace(/[/]+/g, '/')
     this.name = options.name
   }
 
+  get (params) {
+    return this.httpClient.get(this.path, translateNestedParameters(params))
+  }
+
+  getOne (id, params) {
+    return this.httpClient.get(this._pathWithId(id), translateNestedParameters(params || {}))
+  }
+
+  _pathWithId (id) {
+    return `${this.path}${id}`
+  }
+}
+
+class GlobalRegistryReadAndDeleteObject extends GlobalRegistryReadOnlyObject {
+  delete (id) {
+    return this.httpClient.delete(this._pathWithId(id))
+  }
+}
+
+class GlobalRegistryObject extends GlobalRegistryReadAndDeleteObject {
   post (content) {
     return this.httpClient.post(this.path, this._buildBody(content))
   }
 
   put (id, content, options) {
     return this.httpClient.put(this._pathWithId(id), this._buildBody(content), options || {})
-  }
-
-  delete (id) {
-    return this.httpClient.delete(this._pathWithId(id))
-  }
-
-  get (params) {
-    return this.httpClient.get(this.path, translateNestedParameters(params))
-  }
-
-  getOne (id) {
-    return this.httpClient.get(this._pathWithId(id))
-  }
-
-  _pathWithId (id) {
-    return `${this.path}${id}`
   }
 
   _buildBody (content) {
@@ -39,6 +43,30 @@ class GlobalRegistryObject {
   }
 }
 
+class GlobalRegistrySubscriptionObject extends GlobalRegistryReadAndDeleteObject {
+  constructor (httpClient) {
+    super(httpClient, { path: '/subscriptions/', name: 'Subscription' })
+  }
+
+  subscribe (entityTypeId, endpoint, format = 'json') {
+    const payload = {
+      subscription: {
+        entity_type_id: entityTypeId,
+        endpoint: endpoint,
+        format: format
+      }
+    }
+    return this.httpClient.post(this.path, payload)
+  }
+
+  confirm (endpoint) {
+    return this.httpClient.get(endpoint)
+  }
+}
+
 module.exports = {
-  GlobalRegistryObject
+  GlobalRegistryReadOnlyObject,
+  GlobalRegistryReadAndDeleteObject,
+  GlobalRegistryObject,
+  GlobalRegistrySubscriptionObject
 }

--- a/lib/global-registry-object.test.js
+++ b/lib/global-registry-object.test.js
@@ -36,6 +36,17 @@ describe('GlobalRegistryObject', () => {
     expect(mockHttpClient.get.mock.calls[0]).toEqual(['/entity_types/', { 'filter[name]': 'organization' }])
   })
 
+  test('act as Entity - getOne', () => {
+    const mockHttpClient = { get: jest.fn() }
+
+    const id = uuid.v4()
+    const tested = new GlobalRegistryObject(mockHttpClient, { path: '/entities/', name: 'entity' })
+
+    tested.getOne(id)
+    expect(mockHttpClient.get.mock.calls.length).toBe(1)
+    expect(mockHttpClient.get.mock.calls[0]).toEqual(['/entities/' + id])
+  })
+
   test('act as EntityType - post', () => {
     const mockHttpClient = { post: jest.fn() }
 

--- a/lib/global-registry-object.test.js
+++ b/lib/global-registry-object.test.js
@@ -1,14 +1,18 @@
 const rewire = require('rewire')
 const uuid = require('uuid')
 
-const { GlobalRegistryObject } = rewire('./global-registry-object')
+const {
+  GlobalRegistryReadOnlyObject,
+  GlobalRegistryReadAndDeleteObject,
+  GlobalRegistryObject,
+  GlobalRegistrySubscriptionObject } = rewire('./global-registry-object')
 
-describe('GlobalRegistryObject', () => {
+describe('GlobalRegistryReadOnlyObject', () => {
   test('constructor', () => {
     const mockHttpClient = uuid.v4()
     const mockName = uuid.v4()
 
-    const result = new GlobalRegistryObject(mockHttpClient, { path: '/test/', name: mockName })
+    const result = new GlobalRegistryReadOnlyObject(mockHttpClient, { path: '/test/', name: mockName })
 
     expect(result.httpClient).toEqual(mockHttpClient)
     expect(result.path).toEqual('/test/')
@@ -19,7 +23,7 @@ describe('GlobalRegistryObject', () => {
     const mockHttpClient = uuid.v4()
     const mockName = uuid.v4()
 
-    const result = new GlobalRegistryObject(mockHttpClient, { path: 'otherTest', name: mockName })
+    const result = new GlobalRegistryReadOnlyObject(mockHttpClient, { path: 'otherTest', name: mockName })
 
     expect(result.httpClient).toEqual(mockHttpClient)
     expect(result.path).toEqual('/otherTest/')
@@ -29,7 +33,7 @@ describe('GlobalRegistryObject', () => {
   test('act as EntityType - get', () => {
     const mockHttpClient = { get: jest.fn() }
 
-    const tested = new GlobalRegistryObject(mockHttpClient, { path: '/entity_types/', name: 'entity_type' })
+    const tested = new GlobalRegistryReadOnlyObject(mockHttpClient, { path: '/entity_types/', name: 'entity_type' })
 
     tested.get({ filter: { name: 'organization' } })
     expect(mockHttpClient.get.mock.calls.length).toBe(1)
@@ -40,13 +44,27 @@ describe('GlobalRegistryObject', () => {
     const mockHttpClient = { get: jest.fn() }
 
     const id = uuid.v4()
-    const tested = new GlobalRegistryObject(mockHttpClient, { path: '/entities/', name: 'entity' })
+    const tested = new GlobalRegistryReadOnlyObject(mockHttpClient, { path: '/entities/', name: 'entity' })
 
     tested.getOne(id)
     expect(mockHttpClient.get.mock.calls.length).toBe(1)
-    expect(mockHttpClient.get.mock.calls[0]).toEqual(['/entities/' + id])
+    expect(mockHttpClient.get.mock.calls[0]).toEqual(['/entities/' + id, {}])
   })
+})
 
+describe('GlobalRegistryReadAndDeleteObject', () => {
+  test('act as EntityType - delete', () => {
+    const mockHttpClient = { delete: jest.fn() }
+
+    const tested = new GlobalRegistryReadAndDeleteObject(mockHttpClient, { path: '/entity_types/', name: 'entity_type' })
+
+    tested.delete(12345)
+    expect(mockHttpClient.delete.mock.calls.length).toBe(1)
+    expect(mockHttpClient.delete.mock.calls[0]).toEqual(['/entity_types/12345'])
+  })
+})
+
+describe('GlobalRegistryObject', () => {
   test('act as EntityType - post', () => {
     const mockHttpClient = { post: jest.fn() }
 
@@ -66,14 +84,23 @@ describe('GlobalRegistryObject', () => {
     expect(mockHttpClient.put.mock.calls.length).toBe(1)
     expect(mockHttpClient.put.mock.calls[0]).toEqual(['/entity_types/1234', { entity_type: { name: 'somename' } }, {}])
   })
+})
 
-  test('act as EntityType - delete', () => {
-    const mockHttpClient = { delete: jest.fn() }
+describe('GlobalRegistrySubscriptionObject', () => {
+  test('act as EntityType - subscribe', () => {
+    const mockHttpClient = { post: jest.fn() }
 
-    const tested = new GlobalRegistryObject(mockHttpClient, { path: '/entity_types/', name: 'entity_type' })
-
-    tested.delete(12345)
-    expect(mockHttpClient.delete.mock.calls.length).toBe(1)
-    expect(mockHttpClient.delete.mock.calls[0]).toEqual(['/entity_types/12345'])
+    const tested = new GlobalRegistrySubscriptionObject(mockHttpClient)
+    const endpoint = `http://${uuid.v4()}.localhost/`
+    const expectedParams = {
+      subscription: {
+        endpoint: endpoint,
+        entity_type_id: 'person',
+        format: 'json'
+      }
+    }
+    tested.subscribe('person', endpoint)
+    expect(mockHttpClient.post.mock.calls.length).toBe(1)
+    expect(mockHttpClient.post.mock.calls[0]).toEqual(['/subscriptions/', expectedParams])
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3136,6 +3136,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "6.5.5",
         "har-schema": "2.0.0"


### PR DESCRIPTION
1. REST "member" GET endpoint (eg. `/entities/{ID}`  the opposite to "collection" GET: `/entities`)
2. Specific Subscription functions
3. "read only" endpoints (`MeasurementType `) vs "read-write'